### PR TITLE
feat: update BullMQ to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "bullmq": "^3.15.8"
+    "bullmq": "^4.12.3"
   },
   "devDependencies": {
     "@adonisjs/application": "^5.3.0",


### PR DESCRIPTION
BREAKING-CHANGE: BullMQ was updated to version 4. See https://docs.bullmq.io/changelog#4.0.0-2023-06-21
