### PR TITLE
Upstream changes from Zakodium

### DIFF
--- a/adonis-typings/index.ts
+++ b/adonis-typings/index.ts
@@ -35,9 +35,9 @@ declare module '@ioc:Rlanz/Queue' {
 			options?: DispatchOptions
 		): Promise<Job>;
 		process(): Promise<void>;
-		clear<K extends string>(queue: K): Promise<void>;
-		list(): Promise<Map<string, BullQueue>>;
-		get(): Promise<BullQueue>;
+		clear(queue: string): Promise<void>;
+		list(): Map<string, BullQueue>;
+		get(queueName: string): BullQueue | undefined;
 	}
 
 	export interface JobHandlerContract {

--- a/adonis-typings/index.ts
+++ b/adonis-typings/index.ts
@@ -18,8 +18,8 @@ declare module '@ioc:Rlanz/Queue' {
 
 	export type QueueConfig = {
 		connection: ConnectionOptions;
-		queue: QueueOptions;
-		worker: WorkerOptions;
+		queue: Omit<QueueOptions, 'connection'>;
+		worker: Omit<WorkerOptions, 'connection'>;
 		jobs: JobsOptions;
 	};
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "bullmq": "^3.15.8"
+    "bullmq": "^5.7.6"
   },
   "devDependencies": {
     "@adonisjs/application": "^5.3.0",

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -5,8 +5,8 @@
  * @copyright Romain Lanz <romain.lanz@pm.me>
  */
 
-import { Queue, Worker } from 'bullmq';
 import type { JobsOptions } from 'bullmq';
+import { Queue, Worker } from 'bullmq';
 import type { LoggerContract } from '@ioc:Adonis/Core/Logger';
 import type { ApplicationContract } from '@ioc:Adonis/Core/Application';
 import type { DataForJob, JobsList, QueueConfig } from '@ioc:Rlanz/Queue';
@@ -14,27 +14,7 @@ import type { DataForJob, JobsList, QueueConfig } from '@ioc:Rlanz/Queue';
 export class BullManager {
 	private queues: Map<string, Queue> = new Map();
 
-	constructor(
-		private options: QueueConfig,
-		private logger: LoggerContract,
-		private app: ApplicationContract
-	) {
-		this.queues.set(
-			'default',
-			new Queue('default', {
-				connection: this.options.connection,
-				...this.options.queue,
-			})
-		);
-	}
-
-	public dispatch<K extends keyof JobsList | string>(
-		job: K,
-		payload: DataForJob<K>,
-		options: JobsOptions & { queueName?: string } = {}
-	) {
-		const queueName = options.queueName || 'default';
-
+	private maybeAddQueue(queueName: 'default' | string): Queue {
 		if (!this.queues.has(queueName)) {
 			this.queues.set(
 				queueName,
@@ -44,8 +24,26 @@ export class BullManager {
 				})
 			);
 		}
+		return this.queues.get(queueName) as Queue;
+	}
 
-		return this.queues.get(queueName)!.add(job, payload, {
+	constructor(
+		private options: QueueConfig,
+		private logger: LoggerContract,
+		private app: ApplicationContract
+	) {
+		this.maybeAddQueue('default');
+	}
+
+	public dispatch<K extends keyof JobsList | string>(
+		job: K,
+		payload: DataForJob<K>,
+		options: JobsOptions & { queueName?: string } = {}
+	) {
+		const queueName = options.queueName || 'default';
+
+		const queue = this.maybeAddQueue(queueName);
+		return queue.add(job, payload, {
 			...this.options.jobs,
 			...options,
 		});
@@ -92,7 +90,7 @@ export class BullManager {
 		return this;
 	}
 
-	public async clear<K extends string>(queueName: K) {
+	public async clear(queueName: string) {
 		if (!this.queues.has(queueName)) {
 			return this.logger.info(`Queue [${queueName}] doesn't exist`);
 		}
@@ -108,13 +106,15 @@ export class BullManager {
 		return this.queues;
 	}
 
-	public get<K extends string>(queueName: K) {
+	public get(queueName: string) {
 		if (!this.queues.has(queueName)) {
 			return this.logger.info(`Queue [${queueName}] doesn't exist`);
 		}
 
 		return this.queues.get(queueName);
 	}
+
+	public getOrSet(queueName: string): Queue {
+		return this.maybeAddQueue(queueName);
+	}
 }
-
-

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -117,4 +117,11 @@ export class BullManager {
 	public getOrSet(queueName: string): Queue {
 		return this.maybeAddQueue(queueName);
 	}
+
+	public async closeAll() {
+		for (const [queueName, queue] of this.queues.entries()) {
+			await queue.close();
+			this.queues.delete(queueName);
+		}
+	}
 }

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -31,9 +31,7 @@ export class BullManager {
 		private options: QueueConfig,
 		private logger: LoggerContract,
 		private app: ApplicationContract
-	) {
-		this.maybeAddQueue('default');
-	}
+	) {}
 
 	public dispatch<K extends keyof JobsList | string>(
 		job: K,

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -62,7 +62,7 @@ export class BullManager {
 				try {
 					jobHandler = this.app.container.make(job.name, [job]);
 				} catch (e) {
-					this.logger.error(`Job handler for ${job.name} not found`);
+					this.logger.error(e, `Job handler for ${job.name} failed to load`);
 					return;
 				}
 


### PR DESCRIPTION
This PR attempts to upstream all the changes we have in our fork that are required for our current application to work.

- [feat: update BullMQ to v5](https://github.com/RomainLanz/adonis-bull-queue/commit/24d6e98eb052c2e522eb0045f5bf1e6aa759da90) 
  BREAKING-CHANGE: New BullMQ version changes the data format and requires to upgrade all workers to the new version.
- [fix: better error message when job cannot be loaded](https://github.com/RomainLanz/adonis-bull-queue/commit/a2290c5c13e1f2dc1095ce91bb3445ce26c5c95d) 
  Not found is not always the reason. For example, loading a job's dependency could throw.
  Logging the error helps to understand the underlying issue.
- [fix: typings for clear, list and get methods](https://github.com/RomainLanz/adonis-bull-queue/commit/e86ebb61bc5d9cbe86e3a04e2a6ffa122cda99ee)
  - `list` and `get` don't return promises
  - The generic type of `clear` is useless
- [feat: add getOrSet method](https://github.com/RomainLanz/adonis-bull-queue/commit/829d4185e33d5bd385ec6d8a782761fd5b50465f)
  Like `get`, but instantiates the queue if it doesn't exist yet.
  Without this method, the only way to get a queue other than the default one is to dispatch a job first.
- [fix: close queues when Adonis app is shutdown](https://github.com/RomainLanz/adonis-bull-queue/pull/36/commits/9060387db9da0d20c8c8863f4481cadf5c542c0e)
  Otherwise it stays alive forever because of the open Redis connection(s).
- [fix: do not create default queue on instantiation](https://github.com/RomainLanz/adonis-bull-queue/pull/36/commits/4a7611227b8132d64399f8080620396b9abc726a)
  This avoids creating a connection to Redis when it's not needed, for example in Ace commands or unit tests.